### PR TITLE
add actix-web example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ cargo run --release --bin=axum-hello-world
 
 # In rewrk tab
 echo "Results for axum:" && ./rewrk -t 12 -c 500 -d 10s -h http://localhost:3000/
-
-# Back to frameworks tab
-cargo run --release --bin=actix-web-hello-world
-
-# In rewrk tab
-echo "Results for actix-web:" && ./rewrk -t 12 -c 500 -d 10s -h http://localhost:3000/
 ```
 
 ## Benchmark Types

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ cargo run --release --bin=axum-hello-world
 
 # In rewrk tab
 echo "Results for axum:" && ./rewrk -t 12 -c 500 -d 10s -h http://localhost:3000/
+
+# Back to frameworks tab
+cargo run --release --bin=actix-web-hello-world
+
+# In rewrk tab
+echo "Results for actix-web:" && ./rewrk -t 12 -c 500 -d 10s -h http://localhost:3000/
 ```
 
 ## Benchmark Types
@@ -43,5 +49,6 @@ Available low-level frameworks:
 Available high-level frameworks:
 
 - [axum](https://github.com/tokio-rs/axum), view [code](frameworks/axum-hello-world/src/main.rs)
+- [actix-web](https://github.com/actix/actix-web), view [code](frameworks/actix-web-hello-world/src/main.rs)
 
 See [results](results/hello-world.md).

--- a/frameworks/Cargo.toml
+++ b/frameworks/Cargo.toml
@@ -2,5 +2,6 @@
 
 members = [
 	"hyper-hello-world",
+	"actix-web-hello-world",
 	"axum-hello-world"
 ]

--- a/frameworks/actix-web-hello-world/Cargo.toml
+++ b/frameworks/actix-web-hello-world/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "actix-web-hello-world"
+version = "0.1.0"
+authors = ["smallfish <smallfish.xy@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+actix-web = "3"

--- a/frameworks/actix-web-hello-world/src/main.rs
+++ b/frameworks/actix-web-hello-world/src/main.rs
@@ -1,0 +1,13 @@
+use actix_web::{web, App, HttpServer};
+
+async fn index() -> &'static str {
+    "Hello, World!"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| App::new().service(web::resource("/").to(index)))
+        .bind("127.0.0.1:3000")?
+        .run()
+        .await
+}

--- a/frameworks/axum-hello-world/src/main.rs
+++ b/frameworks/axum-hello-world/src/main.rs
@@ -1,7 +1,7 @@
 use tokio::net::TcpListener;
 
-use hyper::{Body, Response};
 use hyper::server::conn::Http;
+use hyper::{Body, Response};
 
 use axum::prelude::*;
 use axum::routing::nest;
@@ -12,7 +12,10 @@ type AnyError = Box<dyn std::error::Error + Send + Sync>;
 async fn main() -> Result<(), AnyError> {
     let listener = TcpListener::bind("127.0.0.1:3000").await?;
 
-    let app = nest("/", get(|| async { Response::new(Body::from("Hello, World!")) }));
+    let app = nest(
+        "/",
+        get(|| async { Response::new(Body::from("Hello, World!")) }),
+    );
 
     loop {
         let (stream, _addr) = listener.accept().await?;
@@ -20,8 +23,7 @@ async fn main() -> Result<(), AnyError> {
         let app = app.clone();
 
         tokio::spawn(async move {
-            let fut = Http::new()
-                .serve_connection(stream, app);
+            let fut = Http::new().serve_connection(stream, app);
 
             match fut.await {
                 Ok(()) => (),

--- a/frameworks/hyper-hello-world/src/main.rs
+++ b/frameworks/hyper-hello-world/src/main.rs
@@ -2,9 +2,9 @@ use std::convert::Infallible;
 
 use tokio::net::TcpListener;
 
-use hyper::{Body, Request, Response};
-use hyper::service::service_fn;
 use hyper::server::conn::Http;
+use hyper::service::service_fn;
+use hyper::{Body, Request, Response};
 
 type AnyError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -16,8 +16,7 @@ async fn main() -> Result<(), AnyError> {
         let (stream, _addr) = listener.accept().await?;
 
         tokio::spawn(async move {
-            let fut = Http::new()
-                .serve_connection(stream, service_fn(serve));
+            let fut = Http::new().serve_connection(stream, service_fn(serve));
 
             match fut.await {
                 Ok(()) => (),
@@ -27,9 +26,7 @@ async fn main() -> Result<(), AnyError> {
     }
 }
 
-async fn serve(
-  _req: Request<Body>
-) -> Result<Response<Body>, Infallible> {
+async fn serve(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let resp = Response::new(Body::from("Hello World!"));
 
     Ok(resp)


### PR DESCRIPTION
benchmark with my MBP(rewrk with `-c 100`) the results:

```bash
$ echo "Results for hyper:" && ./rewrk -t 12 -c 100 -d 10s -h http://localhost:3000/
Results for hyper:
Beginning round 1...
Benchmarking 100 connections @ http://localhost:3000/ for 10 second(s)
  Latencies:
    Avg      Stdev    Min      Max
    1.28ms   0.90ms   0.07ms   9.99ms
  Requests:
    Total: 774594  Req/Sec: 77440.91
  Transfer:
    Total: 65.01 MB Transfer Rate: 6.50 MB/Sec


$ echo "Results for axum:" && ./rewrk -t 12 -c 100 -d 10s -h http://localhost:3000/
Results for axum:
Beginning round 1...
Benchmarking 100 connections @ http://localhost:3000/ for 10 second(s)
  Latencies:
    Avg      Stdev    Min      Max
    1.27ms   0.80ms   0.08ms   8.55ms
  Requests:
    Total: 780470  Req/Sec: 78041.91
  Transfer:
    Total: 66.24 MB Transfer Rate: 6.62 MB/Sec


$ echo "Results for actix-web:" && ./rewrk -t 12 -c 100 -d 10s -h http://localhost:3000/
Results for actix-web:
Beginning round 1...
Benchmarking 100 connections @ http://localhost:3000/ for 10 second(s)
  Latencies:
    Avg      Stdev    Min      Max
    1.55ms   1.82ms   0.07ms   14.54ms
  Requests:
    Total: 642066  Req/Sec: 64173.35
  Transfer:
    Total: 79.60 MB Transfer Rate: 7.96 MB/Sec
```